### PR TITLE
Add color mixer and brightness modulation ip

### DIFF
--- a/Problem1/src/bm_tb.v
+++ b/Problem1/src/bm_tb.v
@@ -1,0 +1,44 @@
+`include "brtns_mod.v"
+`timescale 1ns/1ps
+
+module bm_tb;
+  reg        clk, rst, timeout_cm;
+  reg  [4:0] brtns;
+  wire on_pwm, timeout_bm;
+
+  brtns_mod cm (
+    .clk_i    (clk),
+    .rst_i    (rst),
+    .brtns_i  (brtns),
+    .timeout_i(timeout_cm),
+    .on_pwm_o (on_pwm),
+    .timeout_o(timeout_bm)
+  );
+
+  initial begin
+    clk = 1;
+    brtns = 5'd10;
+    rst = 1;
+    #10;
+    rst = 0;
+    #5000;
+    $finish;
+  end
+
+  always begin
+    clk = #4 ~clk;
+  end
+
+  always begin
+    timeout_cm = 0;
+    #80;  // actually it is 256 clock cycles
+    timeout_cm = 1;
+    #8;
+  end
+
+  initial begin
+    $dumpfile("bm.vcd");
+    $dumpvars;
+  end
+
+endmodule

--- a/Problem1/src/brtns_mod.v
+++ b/Problem1/src/brtns_mod.v
@@ -13,16 +13,16 @@ module brtns_mod (
   output      timeout_o
 );
 
-  reg [4:0] counter;
+  reg [4:0] cnt;
 
-  assign on_pwm_o  = counter < brtns_i;
-  assign timeout_o = &counter;
+  assign on_pwm_o  = cnt < brtns_i;
+  assign timeout_o = &cnt;
 
   always @(posedge clk_i or posedge rst_i) begin
     if (rst_i) begin
-      counter <= 5'd0;
+      cnt <= 5'd0;
     end else begin
-      counter <= (timeout_i)? counter + 5'd1 : counter;
+      cnt <= (timeout_i)? cnt + 5'd1 : cnt;
     end
   end
 

--- a/Problem1/src/brtns_mod.v
+++ b/Problem1/src/brtns_mod.v
@@ -13,4 +13,17 @@ module brtns_mod (
   output      timeout_o
 );
 
+  reg [4:0] counter;
+
+  assign on_pwm_o = counter < brtns_i;
+  assign timeout_o = &counter;
+
+  always @(posedge clk_i or posedge rst_i) begin
+    if (rst_i) begin
+      counter <= 5'd0;
+    end else begin
+      counter <= (timeout_i)? counter + 5'd1 : counter;
+    end
+  end
+
 endmodule

--- a/Problem1/src/brtns_mod.v
+++ b/Problem1/src/brtns_mod.v
@@ -1,0 +1,16 @@
+/* brtns_mod.v
+ *
+ * Brightness modulation module that modulates the brightness using 1-bit pwm 
+ * signal `on_pwm_o`. `timeout_o` is pulled every 32 `timeout_i`, which is from
+ * color_mixer.
+ */
+module brtns_mod (
+  input       clk_i,
+  input       rst_i,
+  input       timeout_i,
+  input [4:0] brtns_i,
+  output      on_pwm_o,
+  output      timeout_o
+);
+
+endmodule

--- a/Problem1/src/brtns_mod.v
+++ b/Problem1/src/brtns_mod.v
@@ -15,7 +15,7 @@ module brtns_mod (
 
   reg [4:0] counter;
 
-  assign on_pwm_o = counter < brtns_i;
+  assign on_pwm_o  = counter < brtns_i;
   assign timeout_o = &counter;
 
   always @(posedge clk_i or posedge rst_i) begin

--- a/Problem1/src/cm_tb.v
+++ b/Problem1/src/cm_tb.v
@@ -1,0 +1,37 @@
+`include "color_mixer.v"
+`timescale 1ns/1ps
+
+module cm_tb;
+  reg         clk, rst;
+  reg  [23:0] color;
+  wire [2:0]  rgb_pwm;
+  wire        timeout;
+
+  color_mixer cm (
+    .clk_i    (clk),
+    .rst_i    (rst),
+    .color_i  (color),
+    .rgb_pwm_o(rgb_pwm),
+    .timeout_o(timeout)
+  );
+
+  initial begin
+    clk = 0;
+    color = 24'h7f1fff;
+    rst = 1;
+    #15;
+    rst = 0;
+    #5000;
+    $finish;
+  end
+
+  always begin
+    clk = #4 ~clk;
+  end
+
+  initial begin
+    $dumpfile("cm.vcd");
+    $dumpvars;
+  end
+
+endmodule

--- a/Problem1/src/cm_tb.v
+++ b/Problem1/src/cm_tb.v
@@ -16,10 +16,10 @@ module cm_tb;
   );
 
   initial begin
-    clk = 0;
+    clk = 1;
     color = 24'h7f1fff;
     rst = 1;
-    #15;
+    #10;
     rst = 0;
     #5000;
     $finish;

--- a/Problem1/src/color_mixer.v
+++ b/Problem1/src/color_mixer.v
@@ -11,4 +11,18 @@ module color_mixer (
   output        timeout_o
 );
 
+  reg  [7:0] counter;
+  wire [7:0] r = color_i[23:16], g = color_i[15:8], b = color_i[7:0];
+
+  assign rgb_pwm_o = {counter < r, counter < g, counter < b};
+  assign timeout_o = &counter;
+
+  always @(posedge clk_i or posedge rst_i) begin
+    if (rst_i) begin
+      counter <= 8'd0;
+    end else begin
+      counter <= counter + 8'd1;
+    end
+  end
+
 endmodule

--- a/Problem1/src/color_mixer.v
+++ b/Problem1/src/color_mixer.v
@@ -1,0 +1,14 @@
+/* color_mixer.v
+ *
+ * Color mixer module that reads input 24-bit RGB code and outputs 3-bit RGB pwm
+ * signal `rgb_pwm_o`. `timeout_o` is pulled up every 255 clk cycles.
+ */
+module color_mixer (
+  input         clk_i,
+  input         rst_i,
+  input  [23:0] color_i,
+  output [2:0]  rgb_pwm_o,
+  output        timeout_o
+);
+
+endmodule

--- a/Problem1/src/color_mixer.v
+++ b/Problem1/src/color_mixer.v
@@ -11,10 +11,13 @@ module color_mixer (
   output        timeout_o
 );
 
-  reg  [7:0] counter;
-  wire [7:0] r = color_i[23:16], g = color_i[15:8], b = color_i[7:0];
+  reg [7:0] counter;
 
-  assign rgb_pwm_o = {counter < r, counter < g, counter < b};
+  assign rgb_pwm_o = {
+    counter < color_i[23:16],
+    counter < color_i[15:8],
+    counter < color_i[7:0]
+  };
   assign timeout_o = &counter;
 
   always @(posedge clk_i or posedge rst_i) begin

--- a/Problem1/src/color_mixer.v
+++ b/Problem1/src/color_mixer.v
@@ -11,20 +11,20 @@ module color_mixer (
   output        timeout_o
 );
 
-  reg [7:0] counter;
+  reg [7:0] cnt;
 
   assign rgb_pwm_o = {
-    counter < color_i[23:16],
-    counter < color_i[15:8],
-    counter < color_i[7:0]
+    cnt < color_i[23:16],
+    cnt < color_i[15:8],
+    cnt < color_i[7:0]
   };
-  assign timeout_o = &counter;
+  assign timeout_o = &cnt;
 
   always @(posedge clk_i or posedge rst_i) begin
     if (rst_i) begin
-      counter <= 8'd0;
+      cnt <= 8'd0;
     end else begin
-      counter <= counter + 8'd1;
+      cnt <= cnt + 8'd1;
     end
   end
 


### PR DESCRIPTION
I added the two ip's: `color_mixer.v` and `brtns_mod.v`.

Given 24-bit RGB color code as input, the color mixer will output 3-bit RGB pwm signal `rgb_pwm_o`.

As for brightness modulation, given 5-bit brightness as input, it outputs 1-bit pwm signal `on_pwm_o`.

Also, I wrote two simple testbenches to test the module. Please see the simulation result.
### color mixer
- given `color = 0x7f1fff`
- timeouts every 256 clock cycles

![image](https://user-images.githubusercontent.com/79467307/160246801-b91e4f33-4e82-40e6-be09-aa8ddf5693d3.png)

### brightness modulation
- given `brtns = 10` (brightness)
- timeouts every 32 timeout_cm

![image](https://user-images.githubusercontent.com/79467307/160246845-754e7288-0684-4473-a0b4-74b27d5844bb.png)
